### PR TITLE
feat: allow passing options to the drawer renderer, add UI controls demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openseadragon",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openseadragon",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "eslint-plugin-compat": "^4.1.2",

--- a/src/webgl/drawer.js
+++ b/src/webgl/drawer.js
@@ -1,5 +1,4 @@
 // 700 riadkov
-
 /*
  * OpenSeadragon - WebGLDrawer
  *

--- a/src/webgl/plainShader.js
+++ b/src/webgl/plainShader.js
@@ -33,10 +33,8 @@
             // osd_texture(0, osd_texture_coords).rgba
             return `
         return ${this.sampleChannel("v_texture_coords")};`;
-
             // return just green color
             // return 'return vec4(0, 1, 0, 0.5);';
-
         }
     };
 

--- a/src/webgl/shaderLayer.js
+++ b/src/webgl/shaderLayer.js
@@ -213,6 +213,7 @@
             /* only opacity in _ownedControls, dont know where is use_channel0 from plain shader ??? */
             for (let control of this._ownedControls) {
                 // `uniform controlGLtype controlGLname;`
+                // `uniform controlGLtype controlGLname;`
                 let code = this[control].define();
                 if (code) {
                     // trim removes whitespace from beggining and the end of the string

--- a/src/webgl/shaderLayer.js
+++ b/src/webgl/shaderLayer.js
@@ -157,6 +157,8 @@
                 console.error(`Invalid ID for the shader: ${id} does not match to the pattern`, $.WebGLModule.idPattern);
             }
 
+
+            this._controls = {}; // {opacity: {TII_sourceI: UIControl, ...}, color: {TII_sourceI: UIControl, ...}}
             //todo custom control names share namespace with this API - unique names or controls in seperate object?
 
             this.webglContext = privateOptions.webglContext;
@@ -188,6 +190,32 @@
             this.resetChannel(options);
             // nastavi this._mode a this.__mode na "show", inak by mohla aj do cache nastavovat...
             this.resetMode(options);
+        }
+
+        /**
+         *
+         * @param {string} controlId <tiledImageIndex>_<dataSourceIndex> to uniquely identify control
+         */
+        newConstruct(controlId) {
+            const defaultControls = this.constructor.defaultControls;
+            for (let controlName in defaultControls) {
+                const controlObject = defaultControls[controlName];
+                const control = $.WebGLModule.UIControls.build(this, controlName, controlObject, {});
+                this._controls[controlName][controlId] = control;
+            }
+        }
+
+        /**
+         *
+         * @param {string} controlId <tiledImageIndex>_<dataSourceIndex> to uniquely identify control
+         */
+        newAddControl(controlId) {
+            const defaultControls = this.constructor.defaultControls;
+            for (let controlName in defaultControls) {
+                const controlObject = defaultControls[controlName];
+                const control = $.WebGLModule.UIControls.build(this, controlName, controlObject, {});
+                this._controls[controlName][controlId] = control;
+            }
         }
 
         /**

--- a/src/webgl/webGLContext.js
+++ b/src/webgl/webGLContext.js
@@ -260,8 +260,8 @@
                     onError("Unable to use this specification.",
                         "Linking of WebGLProgram failed. For more information, see logs in the $.console.");
                 } else { //if (this.renderer.debug) { //todo uncomment in production
-                    $.console.info("VERTEX SHADER\n", numberLines( opts.vs ));
-                    $.console.info("FRAGMENT SHADER\n", numberLines( opts.fs ));
+                    // $.console.info("VERTEX SHADER\n", numberLines( opts.vs ));
+                    // $.console.info("FRAGMENT SHADER\n", numberLines( opts.fs ));
                 }
             }
         }

--- a/src/webgldrawerModular.js
+++ b/src/webgldrawerModular.js
@@ -99,7 +99,7 @@
                 // Allow override:
                 webglPreferredVersion: "2.0",
                 webglOptions: {},
-                htmlControlsId: null,
+                htmlControlsId: "drawer-controls",
                 htmlShaderPartHeader: (html, dataId, isVisible, layer, isControllable = true) => {
                     return `<div class="configurable-border"><div class="shader-part-name">${dataId}</div>${html}</div>`;
                 },

--- a/src/webgldrawerModular.js
+++ b/src/webgldrawerModular.js
@@ -77,7 +77,7 @@
              */
 
             // private members
-            this._id = Math.random();
+            this._id = Date.now();
             console.log('Drawer ID =', this._id);
             this._destroyed = false;
             this._TextureMap = new Map();
@@ -95,21 +95,27 @@
             this.context = this._outputContext; // API required by tests
 
             /***** SETUP RENDERER *****/
-            const rendererOptions = {
-                uniqueId: "openseadragon", //todo OSD creates multiple drawers - navigator + main + possibly other - find way to differentiate
+            const rendererOptions = $.extend({
+                // Allow override:
                 webglPreferredVersion: "2.0",
                 webglOptions: {},
-                canvasOptions: {
-                    stencil: true
-                },
                 htmlControlsId: null,
                 htmlShaderPartHeader: (html, dataId, isVisible, layer, isControllable = true) => {
                     return `<div class="configurable-border"><div class="shader-part-name">${dataId}</div>${html}</div>`;
                 },
-                ready: () => { },
-                resetCallback: function() { },
-                debug: false
-            };
+                ready: () => {
+                },
+                resetCallback: function () {
+                },
+                debug: false,
+            }, options, {
+                // Do not allow override:
+                uniqueId: "osd_" + this._id,
+                canvasOptions: {
+                    stencil: true
+                }
+            });
+
             // OLD $.extend(this.options, rendererOptions) [this.options are options.options from DRAWERBASE]
             this.renderer = new $.WebGLModule(rendererOptions);
             //this.renderer._createSinglePassShader('TEXTURE_2D');

--- a/test/demo/drawer-ui-controls.html
+++ b/test/demo/drawer-ui-controls.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Drawer Comparison Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <script type="text/javascript" src='../lib/jquery-ui-1.10.2/js/jquery-ui-1.10.2.min.js'></script>
+    <link rel="stylesheet" href="../lib/jquery-ui-1.10.2/css/smoothness/jquery-ui-1.10.2.min.css">
+
+    <script type="module" src="./drawer-ui-controls.js"></script>
+    <style type="text/css">
+        .content{
+            max-width:960px;
+            margin: 0 auto;
+        }
+        .mirrored{
+            display:grid;
+            grid-template-columns:50% 50%;
+            gap: 2em;
+        }
+        .viewer-container {
+            /* width: 600px;
+            height: 400px; */
+            aspect-ratio: 4 / 3;
+            border: thin gray solid;
+            position:relative;
+        }
+        .example-code{
+            background-color:tan;
+            border: thin black solid;
+            padding:10px;
+            display:inline-block;
+            width:95%;
+        }
+        .description pre{
+            display:inline-block;
+            background-color:gainsboro;
+            padding:0;
+            margin:0;
+        }
+
+        .image-options{
+            display: grid;
+            grid-template-columns: 2em 9em 1fr;
+            padding:3px;
+            border: thin gray solid;
+        }
+        .option-grid{
+            display: grid;
+            grid-template-columns: 7em 7em 9em 9em 10em 9em;
+            /* grid-template-columns: repeat(5, auto); */
+        }
+        .image-options input[type=number]{
+            width: 5em;
+        }
+        .image-options select{
+            width: 5em;
+        }
+    </style>
+</head>
+<body>
+    <div class="content">
+
+        <h2>Test <strong>WebGL</strong> drawer control</h2>
+        <div class="mirrored">
+            <div>
+                <h3 id="title-w1">WebGL Modular Drawer</h3>
+                <div id="canvasdrawer" class="viewer-container"></div>
+            </div>
+
+            <div id="drawer-controls">
+
+            </div>
+        </div>
+
+
+        <div id="image-picker">
+            <h3>Image options (drag and drop to re-order images)</h3>
+        </div>
+    </div>
+</body>
+</html>
+

--- a/test/demo/drawer-ui-controls.js
+++ b/test/demo/drawer-ui-controls.js
@@ -72,11 +72,11 @@ $('#image-picker input.toggle').on('change',function(){
     let data = $(this).data();
     if(this.checked){
         addTileSource(viewer1, data.image, this);
-        addTileSource(viewer2, data.image, this);
+        // addTileSource(viewer2, data.image, this);
     } else {
         if(data.item1){
             viewer1.world.removeItem(data.item1);
-            viewer2.world.removeItem(data.item2);
+            // viewer2.world.removeItem(data.item2);
             $(this).data({item1: null, item2: null});
         }
     }

--- a/test/demo/drawer-ui-controls.js
+++ b/test/demo/drawer-ui-controls.js
@@ -1,0 +1,259 @@
+const sources = {
+    "rainbow":"../data/testpattern.dzi",
+    "leaves":"../data/iiif_2_0_sizes/info.json",
+    "bblue":{
+        type:'image',
+        url: "../data/BBlue.png",
+    },
+    "duomo":"https://openseadragon.github.io/example-images/duomo/duomo.dzi",
+}
+const labels = {
+    rainbow: 'Rainbow Grid',
+    leaves: 'Leaves',
+    bblue: 'Blue B',
+    duomo: 'Duomo',
+}
+
+//Support drawer type from the url
+const url = new URL(window.location.href);
+
+
+//Double viewer setup for comparison - CanvasDrawer and WebGLDrawer
+// viewer1: canvas drawer
+let viewer1 = window.viewer1 = OpenSeadragon({
+    id: "canvasdrawer",
+    prefixUrl: "../../build/openseadragon/images/",
+    minZoomImageRatio:0.01,
+    maxZoomPixelRatio:100,
+    smoothTileEdgesMinZoom:1.1,
+    crossOriginPolicy: 'Anonymous',
+    ajaxWithCredentials: false,
+    // maxImageCacheCount: 30,
+    drawer:'myImplementation',
+    drawerOptions: {
+        'myImplementation': {
+            //htmlShaderPartHeader
+            htmlControlsId: 'drawer-controls'
+        }
+    },
+    blendTime:0,
+    showNavigator:true,
+});
+
+
+$('#image-picker').sortable({
+    update: function(event, ui){
+        let thisItem = ui.item.find('.toggle').data('item1');
+        let items = $('#image-picker input.toggle:checked').toArray().map(item=>$(item).data('item1'));
+        let newIndex = items.indexOf(thisItem);
+        if(thisItem){
+            viewer1.world.setItemIndex(thisItem, newIndex);
+        }
+
+        thisItem = ui.item.find('.toggle').data('item2');
+        items = $('#image-picker input.toggle:checked').toArray().map(item=>$(item).data('item2'));
+        newIndex = items.indexOf(thisItem);
+        if(thisItem){
+            viewer2.world.setItemIndex(thisItem, newIndex);
+        }
+    }
+});
+
+Object.keys(sources).forEach((key, index)=>{
+    let element = makeImagePickerElement(key, labels[key])
+    $('#image-picker').append(element);
+    if(index === 0){
+        element.find('.toggle').prop('checked',true);
+    }
+})
+
+
+$('#image-picker input.toggle').on('change',function(){
+    let data = $(this).data();
+    if(this.checked){
+        addTileSource(viewer1, data.image, this);
+        addTileSource(viewer2, data.image, this);
+    } else {
+        if(data.item1){
+            viewer1.world.removeItem(data.item1);
+            viewer2.world.removeItem(data.item2);
+            $(this).data({item1: null, item2: null});
+        }
+    }
+}).trigger('change');
+
+$('#image-picker input:not(.toggle)').on('change',function(){
+    let data = $(this).data();
+    let value = $(this).val();
+    let tiledImage1 = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item1');
+    let tiledImage2 = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item2');
+    updateTiledImage(tiledImage1, data, value, this);
+    updateTiledImage(tiledImage2, data, value, this);
+});
+
+function updateTiledImage(tiledImage, data, value, item){
+    let field = data.field;
+
+    if(tiledImage){
+        //item = tiledImage
+        if(field == 'x'){
+            let bounds = tiledImage.getBoundsNoRotate();
+            let position = new OpenSeadragon.Point(Number(value), bounds.y);
+            tiledImage.setPosition(position);
+        } else if ( field == 'y'){
+            let bounds = tiledImage.getBoundsNoRotate();
+            let position = new OpenSeadragon.Point(bounds.x, Number(value));
+            tiledImage.setPosition(position);
+        } else if (field == 'width'){
+            tiledImage.setWidth(Number(value));
+        } else if (field == 'degrees'){
+            tiledImage.setRotation(Number(value));
+        } else if (field == 'opacity'){
+            tiledImage.setOpacity(Number(value));
+        } else if (field == 'flipped'){
+            tiledImage.setFlip($(item).prop('checked'));
+        } else if (field == 'cropped'){
+            if( $(item).prop('checked') ){
+                let scale = tiledImage.source.width;
+                let croppingPolygons = [ [{x:0.2*scale, y:0.2*scale}, {x:0.8*scale, y:0.2*scale}, {x:0.5*scale, y:0.8*scale}] ];
+                tiledImage.setCroppingPolygons(croppingPolygons);
+            } else {
+                tiledImage.resetCroppingPolygons();
+            }
+        } else if (field == 'clipped'){
+            if( $(item).prop('checked') ){
+                let scale = tiledImage.source.width;
+                let clipRect = new OpenSeadragon.Rect(0.1*scale, 0.2*scale, 0.6*scale, 0.4*scale);
+                tiledImage.setClip(clipRect);
+            } else {
+                tiledImage.setClip(null);
+            }
+        } else if (field == 'debug'){
+            if( $(item).prop('checked') ){
+                tiledImage.debugMode = true;
+            } else {
+                tiledImage.debugMode = false;
+            }
+        }
+    } else {
+        //viewer-level option
+    }
+}
+
+$('.image-options select[data-field=composite]').append(getCompositeOperationOptions()).on('change',function(){
+    let data = $(this).data();
+    let tiledImage1 = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item1');
+    if(tiledImage1){
+        tiledImage1.setCompositeOperation(this.value == 'null' ? null : this.value);
+    }
+    let tiledImage2 = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item2');
+    if(tiledImage2){
+        tiledImage2.setCompositeOperation(this.value == 'null' ? null : this.value);
+    }
+}).trigger('change');
+
+$('.image-options select[data-field=wrapping]').append(getWrappingOptions()).on('change',function(){
+    let data = $(this).data();
+    let tiledImage = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item1');
+    if(tiledImage){
+        switch(this.value){
+            case "None": tiledImage.wrapHorizontal = tiledImage.wrapVertical = false; break;
+            case "Horizontal": tiledImage.wrapHorizontal = true; tiledImage.wrapVertical = false; break;
+            case "Vertical": tiledImage.wrapHorizontal = false; tiledImage.wrapVertical = true; break;
+            case "Both": tiledImage.wrapHorizontal = tiledImage.wrapVertical = true; break;
+        }
+        tiledImage.redraw();//trigger a redraw for the webgl renderer.
+    }
+    tiledImage = $(`#image-picker input.toggle[data-image=${data.image}]`).data('item2');
+    if(tiledImage){
+        switch(this.value){
+            case "None": tiledImage.wrapHorizontal = tiledImage.wrapVertical = false; break;
+            case "Horizontal": tiledImage.wrapHorizontal = true; tiledImage.wrapVertical = false; break;
+            case "Vertical": tiledImage.wrapHorizontal = false; tiledImage.wrapVertical = true; break;
+            case "Both": tiledImage.wrapHorizontal = tiledImage.wrapVertical = true; break;
+        }
+        tiledImage.redraw();//trigger a redraw for the webgl renderer.
+    }
+}).trigger('change');
+
+function getWrappingOptions(){
+    let opts = ['None', 'Horizontal', 'Vertical', 'Both'];
+    let elements = opts.map((opt, i)=>{
+        let el = $('<option>',{value:opt}).text(opt);
+        if(i===0){
+            el.attr('selected',true);
+        }
+        return el[0];
+        // $('.image-options select').append(el);
+    });
+    return $(elements);
+}
+function getCompositeOperationOptions(){
+    let opts = [null,'source-over','source-in','source-out','source-atop',
+                'destination-over','destination-in','destination-out','destination-atop',
+                'lighten','darken','copy','xor','multiply','screen','overlay','color-dodge',
+                'color-burn','hard-light','soft-light','difference','exclusion',
+                'hue','saturation','color','luminosity'];
+    let elements = opts.map((opt, i)=>{
+        let el = $('<option>',{value:opt}).text(opt);
+        if(i===0){
+            el.attr('selected',true);
+        }
+        return el[0];
+        // $('.image-options select').append(el);
+    });
+    return $(elements);
+
+}
+
+function addTileSource(viewer, image, checkbox) {
+    let options = $(`#image-picker input[data-image=${image}][type=number]`).toArray().reduce((acc, input) => {
+        let field = $(input).data('field');
+        if (field) {
+            acc[field] = Number(input.value);
+        }
+        return acc;
+    }, {});
+
+    options.flipped = $(`#image-picker input[data-image=${image}][data-type=flipped]`).prop('checked');
+
+    let items = $('#image-picker input.toggle:checked').toArray();
+    let insertionIndex = items.indexOf(checkbox);
+
+    let tileSource = sources[image];
+    if (tileSource) {
+        viewer && viewer.addTiledImage({tileSource: tileSource, ...options, index: insertionIndex});
+        viewer && viewer.world.addOnceHandler('add-item', function (ev) {
+            let item = ev.item;
+            let field = viewer === viewer1 ? 'item1' : 'item2';
+            $(checkbox).data(field, item);
+            // item.source.hasTransparency = ()=>true; //simulate image with transparency, to show seams in default renderer
+        });
+    }
+}
+
+function makeImagePickerElement(key, label){
+    return $(`<div class="image-options">
+        <span class="ui-icon ui-icon-arrowthick-2-n-s"></span>
+        <label><input type="checkbox" data-image="" class="toggle"> __title__</label>
+        <div class="option-grid">
+            <label>X: <input type="number" value="0" data-image="" data-field="x"> </label>
+            <label>Y: <input type="number" value="0" data-image="" data-field="y"> </label>
+            <label>Width: <input type="number" value="1" data-image="" data-field="width" min="0"> </label>
+            <label>Degrees: <input type="number" value="0" data-image="" data-field="degrees"> </label>
+            <label>Opacity: <input type="number" value="1" data-image="" data-field="opacity" min="0" max="1" step="0.2"> </label>
+            <span></span>
+            <label>Flipped: <input type="checkbox" data-image="" data-field="flipped"></label>
+            <label>Cropped: <input type="checkbox" data-image="" data-field="cropped"></label>
+            <label>Clipped: <input type="checkbox" data-image="" data-field="clipped"></label>
+            <label>Chess Tile Opacity: <input type="checkbox" data-image="" data-field="tile-level-opecity"></label>
+            <label>Debug: <input type="checkbox" data-image="" data-field="debug"></label>
+            <label>Composite: <select data-image="" data-field="composite"></select></label>
+            <label>Wrap: <select data-image="" data-field="wrapping"></select></label>
+        </div>
+    </div>`.replaceAll('data-image=""', `data-image="${key}"`).replace('__title__', label));
+}
+
+
+
+


### PR DESCRIPTION
I added the UI controls demo. I also made a few constructor changes that improve the confgurability (see the demo how can I supply args to the drawer which will be pased to the renderer). However, I am not able to test whether it works or not, because you are no longer calling `_forceSwitchProgram`. You should be calling it (or fix this somehow), because:
 - it drives the UI controls lifecycle as we discussed
 - it implements refresh logics (e.g. UI controls call redraw request), see:
     https://github.com/SamoMUNI/openseadragon/blob/ba44f9725a0f7865182d573dc581775771b8ae0a/src/webgl/shaderLayer.js#L169
     
     https://github.com/SamoMUNI/openseadragon/blob/ba44f9725a0f7865182d573dc581775771b8ae0a/src/webgl/renderer.js#L1050